### PR TITLE
添加支持 Laravel 的中间件 LaravelEngine

### DIFF
--- a/src/LeanCloud/Engine/LaravelEngine.php
+++ b/src/LeanCloud/Engine/LaravelEngine.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace LeanCloud\Engine;
+
+/**
+ * LeanEngine as Laravel middleware
+ *
+ * Add LaravelEngine::class to Laravel middleware stack:
+ *
+ * ```php
+ * // in app/Http/Kernel.php
+ * $middleware = [
+ *     \LeanCloud\Engine\LaravelEngine::class
+ * ];
+ * ```
+ *
+ * @link https://laravel.com/docs/5.1/middleware
+ */
+class LaravelEngine extends LeanEngine {
+
+    /**
+     * Get request header value
+     *
+     * @param string $key Header key
+     * @return string
+     */
+    protected function getHeaderLine($key) {
+        return $this->request->header($key);
+    }
+
+    /**
+     * Get request body string
+     *
+     * @return string
+     */
+    protected function getBody() {
+        return $this->request->getContent();
+    }
+
+    /**
+     * Laravel middleware entry point
+     *
+     * @param  \Illuminate\Http\Reuqest $request Laravel request
+     * @param  \Closure                 $next    Laravel closure
+     * @return mixed
+     */
+    public function handle($request, $next) {
+        $this->request  = $request;
+        $this->dispatch($request->method(),
+                        $request->url());
+        return $next($this->request);
+    }
+}
+

--- a/src/LeanCloud/Engine/LeanEngine.php
+++ b/src/LeanCloud/Engine/LeanEngine.php
@@ -152,9 +152,17 @@ class LeanEngine {
 
     /**
      * Extract variant headers into env
+     *
+     * PHP prepends `HTTP_` to user-defined headers, so `X-MY-VAR`
+     * would be populated as `HTTP_X_MY_VAR`. But 3rd party frameworks
+     * (e.g. Laravel) may overwrite the behavior, and populate it as
+     * cleaner `X_MY_VAR`. So we try to retrieve header value from both
+     * versions.
+     *
      */
     private function parseHeaders() {
         $this->env["ORIGIN"] = $this->retrieveHeader(array(
+            "ORIGIN",
             "HTTP_ORIGIN"
         ));
         $this->env["CONTENT_TYPE"] = $this->retrieveHeader(array(
@@ -162,37 +170,55 @@ class LeanEngine {
             "HTTP_CONTENT_TYPE"
         ));
         $this->env["REMOTE_ADDR"] = $this->retrieveHeader(array(
+            "X_REAL_IP",
             "HTTP_X_REAL_IP",
+            "X_FORWARDED_FOR",
             "HTTP_X_FORWARDED_FOR",
             "REMOTE_ADDR"
         ));
 
         $this->env["LC_ID"] = $this->retrieveHeader(array(
+            "X_LC_ID",
             "HTTP_X_LC_ID",
+            "X_AVOSCLOUD_APPLICATION_ID",
             "HTTP_X_AVOSCLOUD_APPLICATION_ID",
+            "X_ULURU_APPLICATION_ID",
             "HTTP_X_ULURU_APPLICATION_ID"
         ));
         $this->env["LC_KEY"] = $this->retrieveHeader(array(
+            "X_LC_KEY",
             "HTTP_X_LC_KEY",
+            "X_AVOSCLOUD_APPLICATION_KEY",
             "HTTP_X_AVOSCLOUD_APPLICATION_KEY",
+            "X_ULURU_APPLICATION_KEY",
             "HTTP_X_ULURU_APPLICATION_KEY"
         ));
         $this->env["LC_MASTER_KEY"] = $this->retrieveHeader(array(
+            "X_AVOSCLOUD_MASTER_KEY",
             "HTTP_X_AVOSCLOUD_MASTER_KEY",
+            "X_ULURU_MASTER_KEY",
             "HTTP_X_ULURU_MASTER_KEY"
         ));
         $this->env["LC_SESSION"] = $this->retrieveHeader(array(
+            "X_LC_SESSION",
             "HTTP_X_LC_SESSION",
+            "X_AVOSCLOUD_SESSION_TOKEN",
             "HTTP_X_AVOSCLOUD_SESSION_TOKEN",
+            "X_ULURU_SESSION_TOKEN",
             "HTTP_X_ULURU_SESSION_TOKEN"
         ));
         $this->env["LC_SIGN"] = $this->retrieveHeader(array(
+            "X_LC_SIGN",
             "HTTP_X_LC_SIGN",
+            "X_AVOSCLOUD_REQUEST_SIGN",
             "HTTP_X_AVOSCLOUD_REQUEST_SIGN"
         ));
         $prod = $this->retrieveHeader(array(
+            "X_LC_PROD",
             "HTTP_X_LC_PROD",
+            "X_AVOSCLOUD_APPLICATION_PRODUCTION",
             "HTTP_X_AVOSCLOUD_APPLICATION_PRODUCTION",
+            "X_ULURU_APPLICATION_PRODUCTION",
             "HTTP_X_ULURU_APPLICATION_PRODUCTION"
         ));
         $this->env["useProd"] = true;

--- a/src/LeanCloud/Engine/LeanEngine.php
+++ b/src/LeanCloud/Engine/LeanEngine.php
@@ -376,7 +376,7 @@ class LeanEngine {
             $this->processSession();
             if (strpos($pathParts["extra"], "/_ops/metadatas") === 0) {
                 if ($this->env["useMaster"]) {
-                    $this->renderJSON(Cloud::getKeys());
+                    $this->renderJSON(array("result" => Cloud::getKeys()));
                 } else {
                     $this->renderError("Unauthorized.", 401, 401);
                 }

--- a/src/LeanCloud/Engine/LeanEngine.php
+++ b/src/LeanCloud/Engine/LeanEngine.php
@@ -255,8 +255,10 @@ class LeanEngine {
                                   true;
             $this->env["useMaster"] = false;
             // remove internal fields set by API
+            // note we need to preserve `__type` field for object decoding
+            // see #61
             forEach($data as $key) {
-                if ($key[0] === "_") {
+                if ($key[0] === "_" && $key[1] !== "_") {
                     unset($data[$key]);
                 }
             }

--- a/src/LeanCloud/Engine/SlimEngine.php
+++ b/src/LeanCloud/Engine/SlimEngine.php
@@ -32,7 +32,7 @@ class SlimEngine extends LeanEngine {
      * @return string
      */
     protected function getBody() {
-        return $this->response->getBody()->getContents();
+        return $this->request->getBody()->getContents();
     }
 
     /*

--- a/tests/engine/LeanEngineTest.php
+++ b/tests/engine/LeanEngineTest.php
@@ -66,7 +66,7 @@ class LeanEngineTest extends PHPUnit_Framework_TestCase {
 
     public function testGetFuncitonMetadata() {
         $resp = $this->request("/1/functions/_ops/metadatas", "GET");
-        $this->assertContains("hello", $resp);
+        $this->assertContains("hello", $resp["result"]);
     }
 
     public function testCloudFunctionHello() {


### PR DESCRIPTION
在 Laravel 中的使用示例, `app/Http/Kernel.php`：

```php
    protected $middleware = [
        // other middleware ...
        \LeanCloud\Engine\LaravelEngine::class
    ]
```

@jysperm @wujun4code 