### PR TITLE
 修复: 短信验证码登录未正确设置 current user close #55

### DIFF
--- a/src/LeanCloud/LeanUser.php
+++ b/src/LeanCloud/LeanUser.php
@@ -299,6 +299,7 @@ class LeanUser extends LeanObject {
                         "smsCode" => $smsCode);
         $resp = LeanClient::get("/login", $params);
         $user = new static();
+        $user->mergeAfterFetch($resp);
         static::saveCurrentUser($user);
         return $user;
     }


### PR DESCRIPTION
短信验证码登录返回的结果没有合并到当前 user ，导致 user 为空。该 PR 修复此问题。