### PR TITLE
Fix: pass current session token as defalut in request

### DIFF
--- a/src/LeanCloud/LeanClient.php
+++ b/src/LeanCloud/LeanClient.php
@@ -6,6 +6,7 @@ use LeanCloud\LeanBytes;
 use LeanCloud\LeanObject;
 use LeanCloud\LeanACL;
 use LeanCloud\LeanFile;
+use LeanCloud\LeanUser;
 use LeanCloud\Operation\IOperation;
 use LeanCloud\Storage\IStorage;
 use LeanCloud\Storage\SessionStorage;
@@ -225,6 +226,10 @@ class LeanClient {
 
         if ($useMasterKey) {
             $h['X-LC-Sign'] .= ",master";
+        }
+
+        if (!$sessionToken) {
+            $sessionToken = LeanUser::getCurrentSessionToken();
         }
 
         if ($sessionToken) {

--- a/tests/LeanUserTest.php
+++ b/tests/LeanUserTest.php
@@ -3,6 +3,7 @@
 use LeanCloud\LeanClient;
 use LeanCloud\LeanUser;
 use LeanCloud\LeanFile;
+use LeanCloud\LeanQuery;
 use LeanCloud\CloudException;
 use LeanCloud\Storage\SessionStorage;
 
@@ -197,6 +198,19 @@ class LeanUserTest extends PHPUnit_Framework_TestCase {
 
         $user2 = LeanUser::getCurrentUser();
         $this->assertEquals($user2->getUsername(), "alice");
+    }
+
+    /*
+     * To test this case, it is necessary to set "find" permission
+     * to be session user, i.e. allow current logged in user to query only.
+     *
+     * @link https://github.com/leancloud/php-sdk/issues/62
+     */
+    public function testFindUserWithSession() {
+        $user = LeanUser::logIn("alice", "blabla");
+        $query = new LeanQuery("_User");
+        // it should not raise: 1 Forbidden to find by class permission.
+        $query->first();
     }
 
 }


### PR DESCRIPTION
Close #62.

There was not default session token in request, which fails request that
requires session, for example a query over _User table.