### PR TITLE
Feat: log-in with mobile phone and password

### DIFF
--- a/src/LeanCloud/LeanUser.php
+++ b/src/LeanCloud/LeanUser.php
@@ -285,6 +285,23 @@ class LeanUser extends LeanObject {
     }
 
     /**
+     * Log-in user by mobile phone and password
+     *
+     * @param string $phoneNumber
+     * @param string $password
+     * @return LeanUser
+     */
+    public static function logInWithMobilePhone($phoneNumber, $password) {
+        $params = array("mobilePhoneNumber" => $phoneNumber,
+                        "password" => $password);
+        $resp = LeanClient::get("/login", $params);
+        $user = new static();
+        $user->mergeAfterFetch($resp);
+        static::saveCurrentUser($user);
+        return $user;
+    }
+
+    /**
      * Log-in user by mobile phone and SMS code.
      *
      * Log-in user with SMS code, which can be requested by

--- a/src/LeanCloud/LeanUser.php
+++ b/src/LeanCloud/LeanUser.php
@@ -291,10 +291,10 @@ class LeanUser extends LeanObject {
      * @param string $password
      * @return LeanUser
      */
-    public static function logInWithMobilePhone($phoneNumber, $password) {
+    public static function logInWithMobilePhoneNumber($phoneNumber, $password) {
         $params = array("mobilePhoneNumber" => $phoneNumber,
                         "password" => $password);
-        $resp = LeanClient::get("/login", $params);
+        $resp = LeanClient::post("/login", $params);
         $user = new static();
         $user->mergeAfterFetch($resp);
         static::saveCurrentUser($user);

--- a/tests/LeanUserTest.php
+++ b/tests/LeanUserTest.php
@@ -102,6 +102,18 @@ class LeanUserTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals($user, LeanUser::getCurrentUser());
     }
 
+    public function testLoginWithMobilePhone() {
+        $user = LeanUser::logIn("alice", "blabla");
+        $user->setMobilePhoneNumber("18612340000");
+        $user->save();
+        $user->logOut();
+        $this->assertNull(LeanUser::getCurrentUser());
+
+        LeanUser::logInWithMobilePhone("18612340000", "blabla");
+        $user2 = LeanUser::getCurrentUser();
+        $this->assertEquals("alice", $user2->getUsername());
+    }
+
     public function testBecome() {
         $user = LeanUser::logIn("alice", "blabla");
 

--- a/tests/LeanUserTest.php
+++ b/tests/LeanUserTest.php
@@ -102,14 +102,14 @@ class LeanUserTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals($user, LeanUser::getCurrentUser());
     }
 
-    public function testLoginWithMobilePhone() {
+    public function testLoginWithMobilePhoneNumber() {
         $user = LeanUser::logIn("alice", "blabla");
         $user->setMobilePhoneNumber("18612340000");
         $user->save();
         $user->logOut();
         $this->assertNull(LeanUser::getCurrentUser());
 
-        LeanUser::logInWithMobilePhone("18612340000", "blabla");
+        LeanUser::logInWithMobilePhoneNumber("18612340000", "blabla");
         $user2 = LeanUser::getCurrentUser();
         $this->assertEquals("alice", $user2->getUsername());
     }


### PR DESCRIPTION
Close #65 : 支持用手机号和`密码`登录

```php
LeanUser::logInWithMobilePhone($mobilePhone, $password);
```