### PR TITLE
修复创建空 ACL 时的错误 close #84

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ use LeanCloud\LeanUser;
 use LeanCloud\CloudException;
 
 $user = new LeanUser();
-$user->setUsername("alice"):
+$user->setUsername("alice");
 $user->setEmail("alice@example.net");
 $user->setPassword("passpass");
 try {

--- a/src/LeanCloud/LeanACL.php
+++ b/src/LeanCloud/LeanACL.php
@@ -31,12 +31,12 @@ class LeanACL {
      * user will be granted both read and write access. While the
      * latter will be interpretted as JSON encoded array.
      *
+     * With empty param, it creates an ACL with no permission granted.
+     *
      * @param mixed $val LeanUser or JSON encoded ACL array
      */
-    public function __construct($val=null) {
+    public function __construct($val=array()) {
         $this->data = array();
-
-        if (!isset($val)) { return; }
 
         if ($val instanceof LeanUser) {
             $this->setReadAccess($val, true);
@@ -44,14 +44,16 @@ class LeanACL {
         } else if (is_array($val)) {
             forEach($val as $id => $attr) {
                 if (!is_string($id)) {
-                    throw new \RuntimeException("Invalid ACL data");
+                    throw new \RuntimeException("Invalid ACL target");
                 }
                 if (isset($attr["read"]) || isset($attr["write"])) {
                     $this->data[$id] = $attr;
                 } else {
-                    throw new \RuntimeException("Invalid ACL data");
+                    throw new \RuntimeException("Invalid ACL access type");
                 }
             }
+        } else {
+            throw new \RuntimeException("Invalid ACL data.");
         }
     }
 
@@ -65,7 +67,7 @@ class LeanACL {
      */
     private function setAccess($target, $accessType, $flag) {
         if (empty($target)) {
-            throw new \InvalidArgumentException("Access target cannot be empty");
+            throw new \InvalidArgumentException("ACL target cannot be empty");
         }
         if (!in_array($accessType, array("read", "write"))) {
             throw new \InvalidArgumentException("ACL access type must be" .
@@ -296,10 +298,14 @@ class LeanACL {
     /**
      * Encode to JSON representation
      *
-     * @return array
+     * It returns an associative array, or an empty object if
+     * empty. The latter is a workaround as we need to json encode
+     * empty ACL as json object, instead of array.
+     *
+     * @return array|object
      */
     public function encode() {
-        return $this->data;
+        return empty($this->data) ? new \stdClass() : $this->data;
     }
 }
 

--- a/tests/LeanACLTest.php
+++ b/tests/LeanACLTest.php
@@ -22,6 +22,17 @@ class LeanACLTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals(true, $out["id123"]["write"]);
     }
 
+    /**
+     * Empty ACL should be encoded as object, instead of array.
+     *
+     * @link https://github.com/leancloud/php-sdk/issues/84
+     */
+    public function testEmptyACL() {
+        $acl = new LeanACL();
+        $out = $acl->encode();
+        $this->assertEquals("{}", json_encode($out));
+    }
+
     public function testSetPublicAccess() {
         $acl = new LeanACL();
         $acl->setPublicReadAccess(true);

--- a/tests/LeanObjectTest.php
+++ b/tests/LeanObjectTest.php
@@ -137,6 +137,19 @@ class LeanObjectTest extends PHPUnit_Framework_TestCase {
         $obj->destroy();
     }
 
+    public function testCreateObjectWithId() {
+        $obj = new LeanObject("TestObject");
+        $obj->set("foo", "bar");
+        $obj->save();
+        $this->assertNotEmpty($obj->getCreatedAt());
+
+        $obj2 = LeanObject::create("TestObject", $obj->getObjectId());
+        $obj2->fetch();
+        $this->assertEquals("bar", $obj2->get("foo"));
+
+        $obj2->destroy();
+    }
+
     /**
      * Test decoding
      */

--- a/tests/LeanUserTest.php
+++ b/tests/LeanUserTest.php
@@ -192,14 +192,14 @@ class LeanUserTest extends PHPUnit_Framework_TestCase {
     }
 
     /*
-     * Get current user with file attribute will result
-     * circular invoking getCurrentUser.
+     * Get current user with file attribute shall not
+     * circularly invoke getCurrentUser.
      *
      * @link github.com/leancloud/php-sdk#48
      */
     public function testCircularGetCurrentUser() {
         // ensure getCurrentUser neither run indefinetely, nor throw maximum
-        // function all error
+        // function call error
         $avatar = LeanFile::createWithUrl("alice.png", "https://leancloud.cn/favicon.png");
         $user = LeanUser::logIn("alice", "blabla");
         $user->set("avatar", $avatar);


### PR DESCRIPTION
注意：为了将空 ACL json 编码为 object ，而不是 array ，`LeanACL::encode()` 引入了一个不一致的接口： 在 ACL 为空时它会返回 object ，非空时会返回 associative array 。 