### PR TITLE
添加 BatchRequestError 支持更友好的错误提示 close #79

### DIFF
--- a/src/LeanCloud/BatchRequestError.php
+++ b/src/LeanCloud/BatchRequestError.php
@@ -1,0 +1,70 @@
+<?php
+namespace LeanCloud;
+
+/**
+ * Exception thrown when doing batch request
+ */
+class BatchRequestError extends CloudException {
+
+    /**
+     * Array of error response
+     *
+     * @var array
+     */
+    private $errors;
+    
+    public function __construct($message="", $code = 1) {
+        $message = empty($message) ? "Batch request error." : $message;
+        parent::__construct($message, $code);
+    }
+
+    /**
+     * Add a request and error response pair
+     *
+     * Both request and response are expected to be array. The response
+     * array must contain an `error` message, while the request should
+     * contain `method` and `path`.
+     *
+     * @return BatchRequestError
+     */
+    public function add($request, $response) {
+        if (!isset($response["error"])) {
+            throw new \InvalidArgumentException("Invalid error response.");
+        }
+        if (!isset($response["code"])) {
+            $response["code"] = 1;
+        }
+        $response["request"] = $request;
+        $this->errors[] = $response;
+        return $this;
+    }
+
+    /**
+     * Get first error as array that contains request and error response
+     *
+     * It returns null if there are no errors yet.
+     *
+     * @return array|null
+     */
+    public function getFirst() {
+        return isset($this->errors[0]) ? $this->errors[0] : null;
+    }
+
+    /**
+     * Contains error or not
+     *
+     * @return bool
+     */
+    public function empty() {
+        return count($this->errors) == 0;
+    }
+
+    public function __toString() {
+        $message = $this->message;
+        if (!$this->empty()) {
+            $message .= json_encode($this-errors);
+        }
+        return __CLASS__ . ": [{$this->code}]: {$message}\n";
+    }
+}
+

--- a/src/LeanCloud/BatchRequestError.php
+++ b/src/LeanCloud/BatchRequestError.php
@@ -2,7 +2,11 @@
 namespace LeanCloud;
 
 /**
- * Exception thrown when doing batch request
+ * BatchRequestError
+ *
+ * A BatchRequestError object consists of zero or more request and
+ * response errors.
+ *
  */
 class BatchRequestError extends CloudException {
 
@@ -19,7 +23,7 @@ class BatchRequestError extends CloudException {
     }
 
     /**
-     * Add a request and error response pair
+     * Add failed request and its error response
      *
      * Both request and response are expected to be array. The response
      * array must contain an `error` message, while the request should
@@ -40,9 +44,19 @@ class BatchRequestError extends CloudException {
     }
 
     /**
-     * Get first error as array that contains request and error response
+     * Get all error response
      *
-     * It returns null if there are no errors yet.
+     * @return array
+     */
+    public function getAll() {
+        return $this->errors;
+    }
+
+    /**
+     * Get first error response as map
+     *
+     * The returned map contains "code" for error code, "error" for message,
+     * and "request" for request.
      *
      * @return array|null
      */
@@ -51,7 +65,7 @@ class BatchRequestError extends CloudException {
     }
 
     /**
-     * Contains error or not
+     * Contains error response or not
      *
      * @return bool
      */

--- a/src/LeanCloud/BatchRequestError.php
+++ b/src/LeanCloud/BatchRequestError.php
@@ -55,8 +55,9 @@ class BatchRequestError extends CloudException {
     /**
      * Get first error response as map
      *
-     * The returned map contains "code" for error code, "error" for message,
-     * and "request" for request.
+     * Returns associative array of following format:
+     *
+     * `{"code": 101, "error": "error message", "request": {...}}`
      *
      * @return array|null
      */
@@ -69,13 +70,13 @@ class BatchRequestError extends CloudException {
      *
      * @return bool
      */
-    public function empty() {
+    public function isEmpty() {
         return count($this->errors) == 0;
     }
 
     public function __toString() {
         $message = $this->message;
-        if (!$this->empty()) {
+        if (!$this->isEmpty()) {
             $message .= json_encode($this-errors);
         }
         return __CLASS__ . ": [{$this->code}]: {$message}\n";

--- a/src/LeanCloud/LeanClient.php
+++ b/src/LeanCloud/LeanClient.php
@@ -421,10 +421,18 @@ class LeanClient {
                                      $sessionToken,
                                      $headers,
                                      $useMasterKey);
-        if (count($requests) != count($response)) {
-            throw new CloudException("Number of resquest and response " .
-                                    "mismatch in batch operation!");
+
+        $batchRequestError = new BatchRequestError();
+        forEach($requests as $i => $req) {
+            if (isset($response[$i]["error"])) {
+                $batchRequestError->add($req, $response[$i]["error"]);
+            }
         }
+
+        if (!$batchRequestError->isEmpty()) {
+            throw $batchRequestError;
+        }
+
         return $response;
     }
 

--- a/src/LeanCloud/LeanObject.php
+++ b/src/LeanCloud/LeanObject.php
@@ -471,11 +471,9 @@ class LeanObject {
                     $batchRequestError->add($requests[$i],
                                             array("error" => "Object not found."));
                 }
-            } else {
-                $batchRequestError->add($requests[$i], $response[$i]);
             }
         }
-        if (!$batchRequestError->empty()) {
+        if (!$batchRequestError->isEmpty()) {
             throw $batchRequestError;
         }
     }
@@ -661,18 +659,10 @@ class LeanObject {
         $sessionToken = LeanUser::getCurrentSessionToken();
         $response = LeanClient::batch($requests, $sessionToken);
 
-        // TODO: append remaining unsaved items to errors, so user
-        // knows all objects that failed to save?
-        $batchRequestError = new BatchRequestError();
         forEach($objects as $i => $obj) {
             if (isset($response[$i]["success"])) {
                 $obj->mergeAfterSave($response[$i]["success"]);
-            } else {
-                $batchRequestError->add($requests[$i], $response[$i]);
             }
-        }
-        if (!$batchRequestError->empty()) {
-            throw $batchRequestError;
         }
 
         // start next batch
@@ -708,16 +698,6 @@ class LeanObject {
 
         $sessionToken = LeanUser::getCurrentSessionToken();
         $response = LeanClient::batch($requests, $sessionToken);
-
-        $batchRequestError = new BatchRequestError();
-        forEach($objects as $i => $obj) {
-            if (isset($response[$i]["error"])) {
-                $batchRequestError->add($requests[$i], $response[$i]);
-            }
-        }
-        if (!$batchRequestError->empty()) {
-            throw $batchRequestError;
-        }
     }
 }
 


### PR DESCRIPTION
优化 LeanObject save, fetch, destroy 的错误提示，返回更友好的单个错误提示。

@aisk 