### PR TITLE
增加调试模式及 bug 修复

### DIFF
--- a/src/LeanCloud/Client.php
+++ b/src/LeanCloud/Client.php
@@ -555,8 +555,9 @@ class Client {
             }
         } else if ($value instanceof IOperation ||
                    $value instanceof GeoPoint   ||
-                   $value instanceof Bytes  ||
-                   $value instanceof ACL    ||
+                   $value instanceof Bytes      ||
+                   $value instanceof ACL        ||
+                   $value instanceof Relation   ||
                    $value instanceof File) {
             return $value->encode();
         } else if (is_array($value)) {

--- a/src/LeanCloud/Client.php
+++ b/src/LeanCloud/Client.php
@@ -90,11 +90,11 @@ class Client {
     private static $useMasterKey = false;
 
     /**
-     * Use production or not
+     * Is in production or not
      *
      * @var bool
      */
-    private static $useProduction = false;
+    public static $isProduction = false;
 
     /**
      * Default request headers
@@ -179,10 +179,10 @@ class Client {
     /**
      * Use production or not
      *
-     * @param bool $flag
+     * @param bool $flag Default `false`
      */
     public static function useProduction($flag) {
-        self::$useProduction = $flag ? true : false;
+        self::$isProduction = $flag ? true : false;
     }
 
     /**
@@ -219,7 +219,7 @@ class Client {
         }
         $h = self::$defaultHeaders;
 
-        $h['X-LC-Prod'] = self::$useProduction ? 1 : 0;
+        $h['X-LC-Prod'] = self::$isProduction ? 1 : 0;
 
         $timestamp = time();
         $key       = $useMasterKey ? self::$appMasterKey : self::$appKey;

--- a/src/LeanCloud/Engine/LeanEngine.php
+++ b/src/LeanCloud/Engine/LeanEngine.php
@@ -617,7 +617,7 @@ class LeanEngine {
     private function httpsRedirect() {
         $reqProto = $this->getHeaderLine("HTTP_X_FORWARDED_PROTO");
         if ($reqProto === "http" &&
-            getenv("LC_APP_ENV") === "production") {
+            in_array(getenv("LC_APP_ENV"), array("production", "stg"))) {
             $url = "https://{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}";
             $this->redirect($url);
         }

--- a/src/LeanCloud/Push.php
+++ b/src/LeanCloud/Push.php
@@ -30,6 +30,7 @@ class Push {
     public function __construct($data=array(), $options=array()) {
         $this->data = $data;
         $this->options = $options;
+        $this->options["prod"] = Client::$isProduction ? "prod": "dev";
     }
 
     /**

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -346,6 +346,14 @@ class ClientTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals(116.4, $val->getLongitude());
     }
 
+    public function testEncodeRelation() {
+        $a = new Object("TestObject", "id001");
+        $rel = $a->getRelation("likes");
+        $out = Client::encode($rel);
+        $this->assertEquals("Relation",
+                            $out["__type"]);
+    }
+
     public function testEncodeObjectToJSON() {
         $a = new Object("TestObject", "id001");
         $b = new Object("TestObject", "id002");

--- a/test/PushTest.php
+++ b/test/PushTest.php
@@ -53,6 +53,14 @@ class PushTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals($data, $out["data"]);
     }
 
+    public function testDefaultProd() {
+        $push = new Push(array(
+            "alert" => "Hello world!"
+        ));
+        $out = $push->encode();
+        $this->assertEquals(Client::$isProduction, $out["prod"] == "prod");
+    }
+
     public function testSetProd() {
         $push = new Push(array(
             "alert" => "Hello world!"


### PR DESCRIPTION
- `Client::setDebug(true)` 启用调试模式，可以输出 http 请求到日志，方便调试
- Push 根据环境设置 prod 模式
- 修复 Relation 不能被编码的异常
