### PR TITLE
添加 SaveOption 支持  fetchWhenSave 以及 where

### DIFF
--- a/src/LeanCloud/BatchRequestError.php
+++ b/src/LeanCloud/BatchRequestError.php
@@ -32,14 +32,10 @@ class BatchRequestError extends CloudException {
      * @return BatchRequestError
      */
     public function add($request, $response) {
-        if (!isset($response["error"])) {
-            throw new \InvalidArgumentException("Invalid error response.");
-        }
-        if (!isset($response["code"])) {
-            $response["code"] = 1;
-        }
-        $response["request"] = $request;
-        $this->errors[] = $response;
+        $error["code"] = isset($response["code"]) ? $response["code"] : 1;
+        $error["error"] = "{$error['code']} {$response['error']}:"
+                        . json_encode($request);
+        $this->errors[] = $error;
         return $this;
     }
 

--- a/src/LeanCloud/Object.php
+++ b/src/LeanCloud/Object.php
@@ -42,6 +42,14 @@ class Object {
     private $_operationSet;
 
     /**
+     * Save option of object
+     *
+     * @var SaveOption
+     * @see SaveOption
+     */
+    private $_saveOption;
+
+    /**
      * Make a new *plain* Object.
      *
      * @param string $className
@@ -398,10 +406,14 @@ class Object {
     /**
      * Save object and its children objects and files
      *
+     * @param SaveOption $option
      * @throws CloudException
      */
-    public function save() {
+    public function save($option=null) {
         if (!$this->isDirty()) {return;}
+        if ($option) {
+            $this->_saveOption = $option;
+        }
         try {
             $result = self::saveAll(array($this));
         } catch (BatchRequestError $batchRequestError) {
@@ -699,6 +711,9 @@ class Object {
             } else {
                 $req["method"] = "POST";
                 $req["path"]   = "{$path}/{$obj->getClassName()}";
+            }
+            if ($obj->_saveOption) {
+                $req["params"] = $obj->_saveOption->encode();
             }
             $requests[] = $req;
             $objects[]  = $obj;

--- a/src/LeanCloud/SaveOption.php
+++ b/src/LeanCloud/SaveOption.php
@@ -1,0 +1,44 @@
+<?php
+namespace LeanCloud;
+
+
+/**
+ * Object save option builder
+ */
+class SaveOption {
+
+    /**
+     * Fetch object when save if set to true
+     *
+     * @var bool
+     */
+    public $fetchWhenSave;
+
+    /**
+     * Update object only when where query matches
+     *
+     * @var Query
+     */
+    public $where;
+
+    /**
+     * Encode a save option as array
+     *
+     * @return array
+     */
+    public function encode() {
+        $params = array();
+        if (!is_null($this->fetchWhenSave)) {
+            $params["fetchWhenSave"] = $this->fetchWhenSave ? true : false;
+        }
+        if (!is_null($this->where)) {
+            if ($this->where instanceof Query) {
+                $out = $this->where->encode();
+                $params["where"] = $out["where"];
+            } else {
+                throw new \RuntimeException("where of SaveOption must be Query object.");
+            }
+        }
+        return $params;
+    }
+}

--- a/src/LeanCloud/User.php
+++ b/src/LeanCloud/User.php
@@ -113,11 +113,12 @@ class User extends Object {
     /**
      * Save a signed-up user
      *
+     * @param SaveOption $option
      * @throws CloudException
      */
-    public function save() {
+    public function save($option=null) {
         if ($this->getObjectId()) {
-            parent::save();
+            parent::save($option);
         } else {
             throw new CloudException("Cannot save new user, please signUp ".
                                     "first.");


### PR DESCRIPTION
- 支持 fetchWhenSave #83 
- 保存时支持 where 条件 #49 

``` php
use LeanCloud\Object;
use LeanCloud\SaveOption;
use LeanCloud\Query;

$option = new SaveOption();
$option->fetchWhenSave = true;

$query = new Query("TestObject");
$query->greaterThanOrEqualTo("score", 6);
$option->where = $query;

$obj = new Object("TestObject", "id123");
$obj->save($option);
```
