### PR TITLE
🐛 Fix useRegion

### DIFF
--- a/src/LeanCloud/Client.php
+++ b/src/LeanCloud/Client.php
@@ -167,7 +167,7 @@ class Client {
      */
     public static function useRegion($region) {
         self::assertInitialized();
-        AppRouter::getInstance($this->appId)->setRegion($region);
+        AppRouter::getInstance(self::$appId)->setRegion($region);
     }
 
     /**

--- a/src/LeanCloud/Region.php
+++ b/src/LeanCloud/Region.php
@@ -18,7 +18,7 @@ abstract class Region {
      * @param string $name
      */
     public static function fromName($name) {
-        return constant(self::class . "::" . $name);
+        return constant(self::class . "::" . strtoupper($name));
     }
 }
 


### PR DESCRIPTION
- 现在使用 useRegion 会报错 `Using $this when not in object context`
- 命令行工具设置的 REGION 环境变量是小写的，需要转成大写