### PR TITLE
梳理错误处理

### DIFF
--- a/src/LeanCloud/Client.php
+++ b/src/LeanCloud/Client.php
@@ -435,13 +435,15 @@ class Client {
                                         $errno);
         }
         if (strpos($respType, "text/html") !== false) {
-            throw new CloudException("Bad request", -1);
+            throw new CloudException("Bad response type text/html", -1, $respCode,
+                                     $method, $url);
         }
 
         $data = json_decode($resp, true);
         if (isset($data["error"])) {
             $code = isset($data["code"]) ? $data["code"] : -1;
-            throw new CloudException("{$code} {$data['error']}", $code);
+            throw new CloudException("{$data['error']}", $code, $respCode,
+                                     $method, $url);
         }
         return $data;
     }

--- a/src/LeanCloud/CloudException.php
+++ b/src/LeanCloud/CloudException.php
@@ -5,19 +5,6 @@ namespace LeanCloud;
  * Exception thrown when cloud API returns error
  */
 class CloudException extends \Exception {
-    /**
-     * Error code returned by API
-     *
-     * @var int
-     */
-    public $code;
-
-    /**
-     * Error message returned by API
-     *
-     * @var string
-     */
-    public $message;
 
     /**
      * Http status returned by API

--- a/src/LeanCloud/CloudException.php
+++ b/src/LeanCloud/CloudException.php
@@ -49,8 +49,8 @@ class CloudException extends \Exception {
     }
 
     public function __toString() {
-        $req = $this->method ? "{$this->method} {$this->url} =>": "";
-        return __CLASS__ . ": ${req} [{$this->code}] {$this->message}\n";
+        $req = $this->method ? ": {$this->method} {$this->url}": "";
+        return __CLASS__ . ": [{$this->code}] {$this->message}{$req}\n";
     }
 }
 

--- a/src/LeanCloud/CloudException.php
+++ b/src/LeanCloud/CloudException.php
@@ -43,11 +43,14 @@ class CloudException extends \Exception {
     public function __construct($message, $code = 1, $status = 400,
                                 $method=null, $url=null) {
         parent::__construct($message, $code);
+        $this->status = $status;
+        $this->method = $method;
+        $this->url    = $url;
     }
 
     public function __toString() {
-        $req = $method ? "{$method} {$url}": "";
-        return __CLASS__ . ": [{$this->code}] {$this->message} ${req}\n";
+        $req = $this->method ? "{$this->method} {$this->url} =>": "";
+        return __CLASS__ . ": ${req} [{$this->code}] {$this->message}\n";
     }
 }
 

--- a/src/LeanCloud/CloudException.php
+++ b/src/LeanCloud/CloudException.php
@@ -5,12 +5,49 @@ namespace LeanCloud;
  * Exception thrown when cloud API returns error
  */
 class CloudException extends \Exception {
-    public function __construct($message, $code = 1) {
+    /**
+     * Error code returned by API
+     *
+     * @var int
+     */
+    public $code;
+
+    /**
+     * Error message returned by API
+     *
+     * @var string
+     */
+    public $message;
+
+    /**
+     * Http status returned by API
+     *
+     * @var int
+     */
+    public $status;
+
+    /**
+     * Http method request to API
+     *
+     * @var string
+     */
+    public $method;
+
+    /**
+     * Http url request to API
+     *
+     * @var string
+     */
+    public $url;
+
+    public function __construct($message, $code = 1, $status = 400,
+                                $method=null, $url=null) {
         parent::__construct($message, $code);
     }
 
     public function __toString() {
-        return __CLASS__ . ": [{$this->code}]: {$this->message}\n";
+        $req = $method ? "{$method} {$url}": "";
+        return __CLASS__ . ": [{$this->code}] {$this->message} ${req}\n";
     }
 }
 

--- a/src/LeanCloud/Engine/FunctionError.php
+++ b/src/LeanCloud/Engine/FunctionError.php
@@ -5,8 +5,15 @@ namespace LeanCloud\Engine;
  * Error thrown when invoking function error
  */
 class FunctionError extends \Exception {
-    public function __construct($message, $code = 1) {
+
+    /**
+     * Http status code
+     */
+    public $status;
+
+    public function __construct($message, $code = 1, $status = 400) {
         parent::__construct($message, $code);
+        $this->status = $status;
     }
 
     public function __toString() {

--- a/src/LeanCloud/Engine/FunctionError.php
+++ b/src/LeanCloud/Engine/FunctionError.php
@@ -17,6 +17,6 @@ class FunctionError extends \Exception {
     }
 
     public function __toString() {
-        return __CLASS__ . ": [{$this->code}]: {$this->message}\n";
+        return __CLASS__ . ": [{$this->code}] {$this->message}\n";
     }
 }

--- a/src/LeanCloud/Engine/LeanEngine.php
+++ b/src/LeanCloud/Engine/LeanEngine.php
@@ -571,8 +571,11 @@ class LeanEngine {
         try {
             $this->__dispatch($method, $url);
         } catch (FunctionError $ex) {
-            error_log($ex);
-            error_log($ex->getTraceAsString());
+            $status = (int) $ex->status;
+            if ( $status >= 500) {
+                error_log($ex);
+                error_log($ex->getTraceAsString());
+            }
             $this->renderError("{$ex->getMessage()}", $ex->getCode(), $ex->status);
         } catch (CloudException $ex) {
             error_log($ex);

--- a/src/LeanCloud/Engine/LeanEngine.php
+++ b/src/LeanCloud/Engine/LeanEngine.php
@@ -335,7 +335,7 @@ class LeanEngine {
      * @param string $method Request method
      * @param string $url    Request url
      */
-    protected function dispatch($method, $url) {
+    private function __dispatch($method, $url) {
         if (static::$useHttpsRedirect) {
             $this->httpsRedirect();
         }
@@ -393,41 +393,26 @@ class LeanEngine {
             // extract func params from path:
             // /1.1/call/{0}/{1}
             $funcParams = explode("/", ltrim($pathParts["extra"], "/"));
-            try {
-                if (count($funcParams) == 1) {
-                    // {1,1.1}/functions/{funcName}
-                    $this->dispatchFunc($funcParams[0], $json,
-                                        $pathParts["endpoint"] === "call");
-                } else {
-                    if ($funcParams[0] == "onVerified") {
-                        // {1,1.1}/functions/onVerified/sms
-                        $this->dispatchOnVerified($funcParams[1], $json);
-                    } else if ($funcParams[0] == "_User" &&
-                               $funcParams[1] == "onLogin") {
-                        // {1,1.1}/functions/_User/onLogin
-                        $this->dispatchOnLogin($json);
-                    } else if ($funcParams[0] == "BigQuery" ||
-                               $funcParams[0] == "Insight") {
-                        // {1,1.1}/functions/Insight/onComplete
-                        $this->dispatchOnInsight($json);
-                    } else if (count($funcParams) == 2) {
-                        // {1,1.1}/functions/{className}/beforeSave
-                        $this->dispatchHook($funcParams[0], $funcParams[1], $json);
-                    }
+            if (count($funcParams) == 1) {
+                // {1,1.1}/functions/{funcName}
+                $this->dispatchFunc($funcParams[0], $json,
+                                    $pathParts["endpoint"] === "call");
+            } else {
+                if ($funcParams[0] == "onVerified") {
+                    // {1,1.1}/functions/onVerified/sms
+                    $this->dispatchOnVerified($funcParams[1], $json);
+                } else if ($funcParams[0] == "_User" &&
+                           $funcParams[1] == "onLogin") {
+                    // {1,1.1}/functions/_User/onLogin
+                    $this->dispatchOnLogin($json);
+                } else if ($funcParams[0] == "BigQuery" ||
+                           $funcParams[0] == "Insight") {
+                    // {1,1.1}/functions/Insight/onComplete
+                    $this->dispatchOnInsight($json);
+                } else if (count($funcParams) == 2) {
+                    // {1,1.1}/functions/{className}/beforeSave
+                    $this->dispatchHook($funcParams[0], $funcParams[1], $json);
                 }
-            } catch (FunctionError $ex) {
-                error_log($ex->getMessage());
-                error_log($ex->getTraceAsString());
-                $this->renderError("Cloud function error: {$ex->getMessage()}", $ex->getCode());
-            } catch (CloudException $ex) {
-                error_log($ex->getMessage());
-                error_log($ex->getTraceAsString());
-                $this->renderError("Request to API failed: {$ex->getMessage()}", $ex->getCode());
-            } catch (\Exception $ex) {
-                error_log($ex->getMessage());
-                error_log($ex->getTraceAsString());
-                $this->renderError($ex->getMessage(),
-                                   $ex->getCode() ? $ex->getCode() : 1);
             }
         }
     }
@@ -574,6 +559,33 @@ class LeanEngine {
         $meta["remoteAddress"] = $this->env["REMOTE_ADDR"];
         Cloud::runOnInsight($body, $meta);
         $this->renderJSON(array("result" => "ok"));
+    }
+
+    /**
+     * Dispatch LeanEngine functions.
+     *
+     * @param string $method Request method
+     * @param string $url    Request url
+     */
+    protected function dispatch($method, $url) {
+        try {
+            $this->__dispatch($method, $url);
+        } catch (FunctionError $ex) {
+            error_log($ex);
+            error_log($ex->getTraceAsString());
+            $this->renderError("{$ex->getMessage()}", $ex->getCode(), $ex->status);
+        } catch (CloudException $ex) {
+            error_log($ex);
+            error_log($ex->getTraceAsString());
+            $this->renderError("{$ex->getMessage()}", $ex->getCode(), $ex->status);
+        } catch (\Exception $ex) {
+            error_log($ex);
+            error_log($ex->getTraceAsString());
+            $this->renderError($ex->getMessage(),
+                               $ex->getCode() ? $ex->getCode() : 1,
+                               // unhandled internal exception
+                               500);
+        }
     }
 
     /**

--- a/src/LeanCloud/Query.php
+++ b/src/LeanCloud/Query.php
@@ -712,10 +712,7 @@ class Query {
      */
     public function first() {
         $objects = $this->find($this->skip, 1);
-        if (empty($objects)) {
-            throw new CloudException("Object not found.", 101);
-        }
-        return $objects[0];
+        return empty($objects) ? null : $objects[0];
     }
 
     /**

--- a/test/APITest.php
+++ b/test/APITest.php
@@ -22,7 +22,7 @@ class LeanAPITest extends TestCase {
         $resp = Client::post("/classes/TestObject", $obj);
 
         $this->setExpectedException("LeanCloud\CloudException",
-                                    "111 Invalid value type for field", 111);
+                                    "Invalid value type for field", 111);
         $resp2 = Client::put("/classes/TestObject/" . $resp["objectId"],
                                  array("name" => array("__op" => "Increment",
                                                        "amount" => 1)));

--- a/test/engine/LeanEngineTest.php
+++ b/test/engine/LeanEngineTest.php
@@ -212,5 +212,15 @@ class LeanEngineTest extends TestCase {
         $this->assertEquals(false, $resp["result"]["drop"]);
     }
 
+    public function testFunctionError() {
+        try {
+            $this->request("/1.1/functions/customError", "POST", array());
+        } catch (CloudException $ex) {
+            $this->assertEquals("My custom error.", $ex->getMessage());
+            $this->assertEquals(1, $ex->getCode());
+            $this->assertEquals(500, $ex->status);
+        }
+    }
+
 }
 

--- a/test/engine/LeanEngineTest.php
+++ b/test/engine/LeanEngineTest.php
@@ -50,6 +50,7 @@ class LeanEngineTest extends TestCase {
         }
         $resp = curl_exec($req);
         $errno = curl_errno($req);
+        $respCode = curl_getinfo($req, CURLINFO_HTTP_CODE);
         curl_close($req);
         if ($errno > 0) {
             throw new \RuntimeException("CURL connection error $errno: $url");
@@ -57,7 +58,8 @@ class LeanEngineTest extends TestCase {
         $data = json_decode($resp, true);
         if (isset($data["error"])) {
             $code = isset($data["code"]) ? $data["code"] : -1;
-            throw new CloudException("{$code} {$data['error']}", $code);
+            throw new CloudException("{$data['error']}", $code, $respCode,
+                                     $method, $url);
         }
         return $data;
     }

--- a/test/engine/index.php
+++ b/test/engine/index.php
@@ -5,6 +5,7 @@ require_once "src/autoload.php";
 use LeanCloud\Client;
 use LeanCloud\Engine\LeanEngine;
 use LeanCloud\Engine\Cloud;
+use LeanCloud\Engine\FunctionError;
 use LeanCloud\Storage\CookieStorage;
 
 Client::initialize(
@@ -23,6 +24,10 @@ Cloud::define("hello", function() {
 // define function with named params
 Cloud::define("sayHello", function($params, $user) {
     return "hello {$params['name']}";
+});
+
+Cloud::define("customError", function($params, $user) {
+    throw new FunctionError("My custom error.", 1, 500);
 });
 
 Cloud::define("_messageReceived", function($params, $user){


### PR DESCRIPTION
* 统一 CloudException ，支持在异常栈中打印 http status, method, url
* 在更上层对云引擎的异常进行处理，避免内部异常没有被 catch https://leanticket.cn/tickets/21441
* 云函数中抛出的异常 FunctionError ，支持自定义 http status
