### PR TITLE
feat: Custome api timeout support

### DIFF
--- a/src/LeanCloud/Client.php
+++ b/src/LeanCloud/Client.php
@@ -139,7 +139,7 @@ class Client {
      * @param int $timeout seconds
      */
     public static function setApiTimeout($seconds) {
-        static::$apiTimeout = $seconds;
+        static::$apiTimeout = intval($seconds);
     }
 
     /**

--- a/src/LeanCloud/Client.php
+++ b/src/LeanCloud/Client.php
@@ -135,8 +135,11 @@ class Client {
     }
 
     /**
-     * settings curl timeout.
-     * @param int $timeout seconds
+     * Set a deadline for requests to complete.
+     *
+     * Note that file upload requests are not affected.
+     *
+     * @param integer $seconds
      */
     public static function setApiTimeout($seconds) {
         static::$apiTimeout = intval($seconds);

--- a/src/LeanCloud/Client.php
+++ b/src/LeanCloud/Client.php
@@ -135,6 +135,14 @@ class Client {
     }
 
     /**
+     * settings curl timeout.
+     * @param int $timeout seconds
+     */
+    public static function setTimeout($seconds) {
+        static::$apiTimeout = $seconds;
+    }
+
+    /**
      * Assert client is correctly initialized
      *
      * @throws RuntimeException

--- a/src/LeanCloud/Client.php
+++ b/src/LeanCloud/Client.php
@@ -138,7 +138,7 @@ class Client {
      * settings curl timeout.
      * @param int $timeout seconds
      */
-    public static function setTimeout($seconds) {
+    public static function setApiTimeout($seconds) {
         static::$apiTimeout = $seconds;
     }
 

--- a/test/APITest.php
+++ b/test/APITest.php
@@ -226,5 +226,14 @@ class LeanAPITest extends TestCase {
         Client::delete("/classes/TestObject/{$resp['objectId']}");
     }
 
+    public function testRequestTimeout() {
+        $getTimeout = function() { return static::$apiTimeout; };
+        $getApiTimeout = $getTimeout->bindTo(null, Client::class);
+        $this->assertEquals(15, $getApiTimeout());
+        Client::setApiTimeout(3);
+        $this->assertEquals(3, $getApiTimeout());
+        Client::setApiTimeout(15); // revert to default
+    }
+
 }
 


### PR DESCRIPTION
In order to prevent excessive timeouts from causing the overall collapse of customers, So allow customers to set a custom timeout according to their own situation.